### PR TITLE
Feature/Add-negative-covid-tests-for-mortality-survillence

### DIFF
--- a/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
+++ b/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
@@ -29,6 +29,7 @@ select
 	sum(case when barcode > 1 then 1 else 0 end) as sampled,
 	sum(case when "result" in ('Inconclusive', 'Invalid', 'Negative', 'Positive') then 1 else 0 end) as number_sars_cov_2_tested,
 	sum(case when "result" = 'Positive' then 1 else 0 end) as number_sars_cov_2_positive,
+	sum(case when "result" = 'Negative' then 1 else 0 end) as number_sars_cov_2_negative,
 	cast(current_date as date) as load_date
 from subset_data
 left join {{ ref( 'dim_facility' ) }} as facility on facility.mfl_code = subset_data.mflcode

--- a/models/dmi_reporting/aggregate_mortality_survillence_report.sql
+++ b/models/dmi_reporting/aggregate_mortality_survillence_report.sql
@@ -13,7 +13,9 @@ select
 	mortality.enrolled,
 	mortality.sampled,
 	mortality.number_sars_cov_2_tested,
-	mortality.number_sars_cov_2_positive
+	mortality.number_sars_cov_2_positive,
+	mortality.number_sars_cov_2_negative,
+	cast(current_date as date) as load_date
 from {{ ref('fct_aggregate_mortality_survillence') }} as mortality
 left join {{ ref('dim_facility') }} as facility on facility.facility_key = mortality.facility_key
 left join {{ ref('dim_date') }} as screen_date on screen_date.date_key = mortality.screen_date_key


### PR DESCRIPTION
Adding Negative  Covid test indicator