### PR TITLE
Covid-19, Flu and RSV computation correction

### DIFF
--- a/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
+++ b/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
@@ -37,7 +37,6 @@ select
 	sum(case when eligible = 1 then 1 else 0 end) as eligible,
 	sum(case when enrolled = 1 then 1 else 0 end) as enrolled,
 	sum(case when barcode > 1 then 1 else 0 end) as sampled,
-
 	sum(case when sarcov_result in ('Negative', 'Positive') then 1 else 0 end) as number_sars_cov_2_tested,
 	sum(case when sarcov_result = 'Positive' then 1 else 0 end) as number_sars_cov_2_positive,
 	sum(case when sarcov_result = 'Negative' then 1 else 0 end) as number_sars_cov_2_negative,

--- a/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
+++ b/models/dmi_data_mart/fct_aggregate_mortality_survillence.sql
@@ -38,15 +38,15 @@ select
 	sum(case when enrolled = 1 then 1 else 0 end) as enrolled,
 	sum(case when barcode > 1 then 1 else 0 end) as sampled,
 
-	sum(case when sarcov_result in ('Inconclusive', 'Invalid', 'Negative', 'Positive') then 1 else 0 end) as number_sars_cov_2_tested,
+	sum(case when sarcov_result in ('Negative', 'Positive') then 1 else 0 end) as number_sars_cov_2_tested,
 	sum(case when sarcov_result = 'Positive' then 1 else 0 end) as number_sars_cov_2_positive,
 	sum(case when sarcov_result = 'Negative' then 1 else 0 end) as number_sars_cov_2_negative,
 	
-	sum(case when rsv_result in ('Inconclusive', 'Invalid', 'Negative', 'Positive') then 1 else 0 end) as number_rsv_tested,
+	sum(case when rsv_result in ('Negative', 'Positive') then 1 else 0 end) as number_rsv_tested,
 	sum(case when rsv_result = 'Positive' then 1 else 0 end) as number_rsv_positive,
 	sum(case when rsv_result = 'Negative' then 1 else 0 end) as number_rsv_negative,
 
-	sum(case when flu_result in ('Inconclusive', 'Invalid', 'Negative', 'Positive') then 1 else 0 end) as number_flu_tested,
+	sum(case when flu_result in ('Negative', 'Positive') then 1 else 0 end) as number_flu_tested,
 	sum(case when flu_result = 'Positive' then 1 else 0 end) as number_flu_positive,
 	sum(case when flu_result = 'Negative' then 1 else 0 end) as number_flu_negative,
 


### PR DESCRIPTION
1. Removed the invalid and Inconclusive results from number tested computation in Covid-19 , Flu and RSV  results.